### PR TITLE
Update members

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -68,6 +68,7 @@ layout: default
         <div class="row">
         {% assign people = site.people | sort: "priority" | reverse %}
         {% for person in people %}
+        {% unless person.former %}{% continue %}{% endunless %}
           <div class="col-sm-3 col-4 mx-auto text-center person">
               {% if person.photo %}
               <img class="img-thumbnail border border-0 rounded-circle"

--- a/_people/ahsan-khan.md
+++ b/_people/ahsan-khan.md
@@ -1,8 +1,6 @@
 ---
-# TEMPLATE FOR ADDING A NEW PERSON
-# DELETE UNUSED (OPTIONAL) TAGS
-name: "Ahsan Raza Khan" # The person's name
-role: "Research Associate" # The person's role (e.g. "PhD Student")
-photo: '/img/people/ahsan.jpg' # OPTIONAL: If not used, it will use the placeholder photo
+name: "Ahsan Raza Khan"
+role: "Research Associate"
+photo: '/img/people/ahsan.jpg'
 ---
 Ahsan Raza Khan is a Research Associate at the SYSTRON lab, which is funded by the EPSRC CHEDDAR project. His research interests include federated learning, vision-assisted wireless networks, digital twins for wireless networks, and privacy-aware machine learning.

--- a/_people/andreas-habegger.md
+++ b/_people/andreas-habegger.md
@@ -1,0 +1,5 @@
+---
+name: "Prof Andreas Habegger"
+role: "Affiliate / Visiting Professor"
+site: "https://www.bfh.ch/de/ueber-die-bfh/personen/bnlrft5stflz/"
+---

--- a/_people/angelo-feraudo.md
+++ b/_people/angelo-feraudo.md
@@ -3,4 +3,5 @@ name: "Angelo Feraudo"
 role: "Affiliate / Visiting PhD Student"
 photo: '/img/people/angelo.png'
 site: 'https://www.unibo.it/sitoweb/angelo.feraudo/en'
+former: true
 ---

--- a/_people/arjuna-sathiaseelan.md
+++ b/_people/arjuna-sathiaseelan.md
@@ -1,0 +1,4 @@
+---
+name: "Dr Arjuna Sathiaseelan"
+role: "Affiliate"
+---

--- a/_people/bidushi-barau.md
+++ b/_people/bidushi-barau.md
@@ -1,0 +1,4 @@
+---
+name: "Dr Bidushi Barua"
+role: "Affiliate / Research Associate"
+---

--- a/_people/brad-davy.md
+++ b/_people/brad-davy.md
@@ -3,6 +3,7 @@ name: "Brad Davy"
 role: "Research Software Engineer"
 photo: '/img/people/brad.png'
 site: 'https://github.com/Brad-Davy'
+former: true
 ---
 
 Supporting research into 6G networks and working in the EPSRC funded CHEDDAR project.

--- a/_people/olufemi-olayiwola.md
+++ b/_people/olufemi-olayiwola.md
@@ -1,0 +1,4 @@
+---
+name: "Dr Olufemi Olayiwola"
+role: "Affiliate / Research Fellow"
+---

--- a/_people/suryachandra-pasupuleti.md
+++ b/_people/suryachandra-pasupuleti.md
@@ -1,0 +1,4 @@
+---
+name: "Suryachandra Prasad Pasupuleti"
+role: "Affiliate / PhD Student"
+---

--- a/_people/template.md
+++ b/_people/template.md
@@ -5,6 +5,7 @@ name: "Template" # The person's name
 role: "" # The person's role (e.g. "PhD Student")
 photo: '' # OPTIONAL: If not used, it will use the placeholder photo
 site: '' # OPTIONAL: A link to the person's personal website
+former: true # OPTIONAL: Remove for members who are currently part of the lab
 ---
 
 <!-- PUT THE PERSON'S DESCRIPTION OR RESEARCH OVERVIEW HERE -->

--- a/_people/xueyu-wu.md
+++ b/_people/xueyu-wu.md
@@ -1,0 +1,4 @@
+---
+name: "Xueyu Wu"
+role: "Affiliate / PhD Student"
+---

--- a/_people/yifan-liu.md
+++ b/_people/yifan-liu.md
@@ -1,0 +1,5 @@
+---
+name: "Yifan Liu"
+role: "Research Software Engineer"
+site: "https://l0exy1h.github.io/york-personal-site/"
+---

--- a/people.html
+++ b/people.html
@@ -7,7 +7,7 @@ background: '/img/systron-team.jpg'
 
 {% assign people = site.people | sort: "priority" | reverse %}
 {% for person in people %}
-
+{% unless person.former %}{% continue %}{% endunless %}
 <article class="post-preview">
   <div class="row">
       <div class="col-md-3">
@@ -29,7 +29,21 @@ background: '/img/systron-team.jpg'
         {% endif %}
       </div>
   </div>
-
 </article>
 <hr>
 {% endfor %}
+
+<article class="post-preview">
+  <h2 class="post-title">Former Members</h2>
+  <ul class="list-group">
+  {% for person in people %}
+   {% if person.former %}
+    {% if person.site %}
+    <li class="list-group-item"><a href="{{ person.site }}" target="_blank">{{ person.name }} ({{ person.role }})</a></li>
+    {% else %}
+    <li class="list-group-item">{{ person.name }} ({{ person.role }})</li>
+    {% endif %}
+   {% endif %}
+  {% endfor %}
+  </ul>
+</article>


### PR DESCRIPTION
This pull request makes a modification to the 'member' template that is backwards-compatible, but introduces a new 'former' tag to allow us to filter current and former members on the homepage and 'people' page. This filter is then added to the relevant pages.